### PR TITLE
remove ctermul line from colors

### DIFF
--- a/colors/jb.vim
+++ b/colors/jb.vim
@@ -66,7 +66,6 @@ function! s:h(group, style)
     \ "ctermfg=" . l:ctermfg
     \ "ctermbg=" . l:ctermbg
     \ "cterm="   (has_key(a:style, "cterm")   ? a:style.cterm    : "NONE")
-    \ "ctermul=" (has_key(a:style, "ctermul") ? a:style.ctermul  : "NONE")
 endfunction
 
 


### PR DESCRIPTION
# Description

Please include a summary of the changes.

If adding or modifying support for plugin or language, add an image of 
Vim using that plugin or language before and after the proposed
changes, as well as an image of the target scheme from the relevant
JetBrains IDE. This is in order to keep this scheme in accordance with
being true to it's purpose of emulating JetBrains IDE themes.

## Before image

Insert before screenshot here, showing all changed elements prior
to modification.

## After image

Insert after screenshot here, showing all changed elements after
modification.

## Target image

Insert screenshot of JetBrains IDE theme here showing what elements
are being emulated by the changes.

# Checklist:

- [ ] My modifications couldn't already be implemented using the
  `jb_color_overrides` global variable
- [ ] I have made any relevant corresponding changes to the documentation
