### PR TITLE
add semantic highlighting

### DIFF
--- a/colors/jb.vim
+++ b/colors/jb.vim
@@ -447,6 +447,24 @@ highlight! link CocGitRemovedSign JBGutterDeletedLine
 if has('nvim')
   highlight! link Statusline StatusLine
   highlight! link WinBarNC JBTree
+
+  " LSP Semantic Token Highlights
+  highlight! link @lsp.type.variable Normal
+  highlight! link @lsp.type.parameter Normal
+  highlight! link @lsp.type.property JBStruct
+  highlight! link @lsp.type.function JBFunction
+  highlight! link @lsp.type.method JBFunction
+  highlight! link @lsp.type.class JBType
+  highlight! link @lsp.type.namespace JBCommentRef
+  highlight! link @lsp.type.decorator JBTag
+  highlight! link @lsp.type.builtinConstant JBConstant
+  highlight! link @lsp.type.typeParameter JBType
+  highlight! link @lsp.type.selfParameter JBKeyword
+  highlight! link @lsp.type.clsParameter JBKeyword
+  " Readonly modifier for global variables and constants
+  highlight! link @lsp.mod.readonly JBConstant
+  highlight! link @lsp.typemod.variable.readonly JBConstant
+
   highlight! link DiagnosticFloatingError ErrorText
   highlight! link DiagnosticFloatingWarn WarningText
   highlight! link DiagnosticFloatingInfo InfoText


### PR DESCRIPTION
# Description

Please include a summary of the changes.

If adding or modifying support for plugin or language, add an image of 
Vim using that plugin or language before and after the proposed
changes, as well as an image of the target scheme from the relevant
JetBrains IDE. This is in order to keep this scheme in accordance with
being true to it's purpose of emulating JetBrains IDE themes.

## Before image

Insert before screenshot here, showing all changed elements prior
to modification.

## After image

Insert after screenshot here, showing all changed elements after
modification.

## Target image

Insert screenshot of JetBrains IDE theme here showing what elements
are being emulated by the changes.

# Checklist:

- [ ] My modifications couldn't already be implemented using the
  `jb_color_overrides` global variable
- [ ] I have made any relevant corresponding changes to the documentation
